### PR TITLE
Feat2/groupadd link

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-JWT_SECRET=1661345818576ea23e0715de8b037b11347960f33eb0d9f7454ec793092e76fd
-JWT_REFRESH_SECRET=2dcd0adf975a7a3e2bf7ad4322c7caed187ce96e1858d0d1832f7c6fb1234a2f
-KAKAO_CLIENT_ID= 38789b5f2f2e16d6229dbc25dc0c776b
-KAKAO_CLIENT_SECRET =Z9bv6VkeepRe2CmkjuPdgLY0HA1x7lGf
-REDIRECT_URI =http://healthkungya.s3-website.ap-northeast-2.amazonaws.com/oauth/kakao/callback

--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 JWT_SECRET=1661345818576ea23e0715de8b037b11347960f33eb0d9f7454ec793092e76fd
 JWT_REFRESH_SECRET=2dcd0adf975a7a3e2bf7ad4322c7caed187ce96e1858d0d1832f7c6fb1234a2f
+KAKAO_CLIENT_ID= 38789b5f2f2e16d6229dbc25dc0c776b
+KAKAO_CLIENT_SECRET =Z9bv6VkeepRe2CmkjuPdgLY0HA1x7lGf
+REDIRECT_URI =http://healthkungya.s3-website.ap-northeast-2.amazonaws.com/oauth/kakao/callback

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /build
+.env

--- a/app.ts
+++ b/app.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import kakaoRouter from "./router/kakao";
+import groupRouter from "./router/group";
 const cors = require("cors");
 const app = express();
 const { swaggerUi, specs } = require("./module/swagger");
@@ -10,6 +11,7 @@ app.use(cors());
 app.set("port", process.env.PORT || 8000);
 
 app.use("/auth", kakaoRouter);
+app.use("/group", groupRouter);
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));
 app.listen(app.get("port"), () => {
   console.log(app.get("port"), "번에서 대기중");

--- a/app.ts
+++ b/app.ts
@@ -1,18 +1,63 @@
+// index.ts
 import express from "express";
+import { createServer } from "http";
+import { Server } from "socket.io";
 import kakaoRouter from "./router/kakao";
 import groupRouter from "./router/group";
+import { Pool, createPool } from "mysql2/promise";
+import { SocketService } from "./services/SocketService";
+import dbConfig from "./config/db.config";
+import { CalendarSocketService } from "./services/calendarServices";
 const cors = require("cors");
-const app = express();
 const { swaggerUi, specs } = require("./module/swagger");
-
 require("dotenv").config();
-app.use(express.json()); // JSON 바디 파서 추가
-app.use(cors());
+
+const app = express();
+const httpServer = createServer(app);
+
+// DB 연결 설정
+const pool = createPool({
+  host: dbConfig.HOST,
+  user: dbConfig.USER,
+  password: dbConfig.PASSWORD,
+  database: dbConfig.DB,
+  port: dbConfig.PORT,
+});
+
+// CORS 설정
+app.use(
+  cors({
+    origin: "*",
+    credentials: true,
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+  })
+);
+
+const io = new Server(httpServer, {
+  cors: {
+    origin: "*",
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+    credentials: true,
+  },
+});
+
+app.use(express.json());
 app.set("port", process.env.PORT || 8000);
 
 app.use("/auth", kakaoRouter);
 app.use("/group", groupRouter);
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));
-app.listen(app.get("port"), () => {
+
+// Socket.IO 서비스 초기화
+const socketService = new SocketService(io, pool);
+const calendarSocketService = new CalendarSocketService(io, pool);
+calendarSocketService.initialize();
+socketService.initialize();
+
+httpServer.listen(app.get("port"), () => {
   console.log(app.get("port"), "번에서 대기중");
 });
+
+export { io };

--- a/controller/group.ts
+++ b/controller/group.ts
@@ -53,6 +53,26 @@ class GroupController {
     }
   };
 
+  public createInviteLink = async (req: AuthRequest, res: Response) => {
+    try {
+      const { groupId } = req.params;
+
+      if (!req.user?.user_id) {
+        return res.status(401).json({ error: "인증이 필요합니다." });
+      }
+
+      const inviteLink = await this.groupService.createInviteLink(
+        parseInt(groupId),
+        req.user.user_id
+      );
+
+      res.json({ inviteLink });
+    } catch (error) {
+      console.error("초대 링크 생성 에러:", error);
+      res.status(500).json({ error: "초대 링크 생성에 실패했습니다." });
+    }
+  };
+
   public getGroupMembers = async (req: AuthRequest, res: Response) => {
     try {
       const { groupId } = req.params;

--- a/controller/group.ts
+++ b/controller/group.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from "express";
+
+import connection from "../db";
+import GroupService from "../services/group";
+interface DecodedToken {
+  user_id: number;
+  iat: number;
+  exp: number;
+}
+interface AuthRequest extends Request {
+  user?: DecodedToken;
+}
+class GroupController {
+  private groupService: GroupService;
+
+  constructor() {
+    this.groupService = new GroupService(connection);
+  }
+  public createGroup = async (req: AuthRequest, res: Response) => {
+    try {
+      if (!req.user?.user_id) {
+        return res.status(401).json({ error: "인증이 필요합니다." });
+      }
+
+      const { name } = req.body;
+      const group = await this.groupService.createGroup(
+        { name },
+        req.user.user_id
+      );
+
+      res.status(201).json(group);
+    } catch (error) {
+      console.error("그룹 생성 에러:", error);
+      res.status(500).json({ error: "그룹 생성에 실패했습니다." });
+    }
+  };
+
+  public getGroupDetails = async (req: AuthRequest, res: Response) => {
+    try {
+      const { groupId } = req.params;
+
+      if (!req.user?.user_id) {
+        return res.status(401).json({ error: "인증이 필요합니다." });
+      }
+
+      const groupDetails = await this.groupService.getGroupDetails(
+        parseInt(groupId)
+      );
+      res.json(groupDetails);
+    } catch (error) {
+      console.error("그룹 조회 에러:", error);
+      res.status(500).json({ error: "그룹 조회에 실패했습니다." });
+    }
+  };
+
+  public getGroupMembers = async (req: AuthRequest, res: Response) => {
+    try {
+      const { groupId } = req.params;
+
+      if (!req.user?.user_id) {
+        return res.status(401).json({ error: "인증이 필요합니다." });
+      }
+
+      const members = await this.groupService.getGroupMembers(
+        parseInt(groupId)
+      );
+      res.json(members);
+    } catch (error) {
+      console.error("멤버 조회 에러:", error);
+      res.status(500).json({ error: "멤버 조회에 실패했습니다." });
+    }
+  };
+}
+export default GroupController;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
-        "mysql2": "^3.11.0"
+        "mysql2": "^3.11.0",
+        "socket.io": "^4.8.1"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -93,6 +94,12 @@
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@types/bcrypt": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
@@ -129,6 +136,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "license": "MIT"
     },
     "node_modules/@types/cors": {
       "version": "2.8.17",
@@ -313,6 +326,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
@@ -636,6 +658,68 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
+      "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
@@ -1755,6 +1839,116 @@
         "node": ">=10"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/sqlstring": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
@@ -1961,6 +2155,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml": {
       "version": "2.0.0-1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
-    "mysql2": "^3.11.0"
+    "mysql2": "^3.11.0",
+    "socket.io": "^4.8.1"
   }
 }

--- a/router/group.ts
+++ b/router/group.ts
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import GroupController from "../controller/group";
+import { verifyTokenMiddleware } from "../authorization/jwt";
+
+const router: Router = Router();
+const groupController = new GroupController();
+
+// 그룹 생성 및 조회
+router.post("/", verifyTokenMiddleware, groupController.createGroup);
+router.get("/:groupId", verifyTokenMiddleware, groupController.getGroupDetails);
+
+// // 초대 링크 관련
+// router.post(
+//   "/invite/:groupId",
+//   verifyTokenMiddleware,
+//   groupController.createInviteLink
+// );
+// router.get("/join/:inviteId", verifyTokenMiddleware, groupController.joinGroup);
+
+// 그룹 멤버 관련
+router.get(
+  "/:groupId/members",
+  verifyTokenMiddleware,
+  groupController.getGroupMembers
+);
+
+export default router;

--- a/router/group.ts
+++ b/router/group.ts
@@ -9,12 +9,12 @@ const groupController = new GroupController();
 router.post("/", verifyTokenMiddleware, groupController.createGroup);
 router.get("/:groupId", verifyTokenMiddleware, groupController.getGroupDetails);
 
-// // 초대 링크 관련
-// router.post(
-//   "/invite/:groupId",
-//   verifyTokenMiddleware,
-//   groupController.createInviteLink
-// );
+// 초대 링크 관련
+router.post(
+  "/invite/:groupId",
+  verifyTokenMiddleware,
+  groupController.createInviteLink
+);
 // router.get("/join/:inviteId", verifyTokenMiddleware, groupController.joinGroup);
 
 // 그룹 멤버 관련

--- a/services/SocketService.ts
+++ b/services/SocketService.ts
@@ -1,0 +1,277 @@
+import { Server, Socket } from "socket.io";
+import { Pool, RowDataPacket } from "mysql2/promise";
+
+interface UserInfo extends RowDataPacket {
+  user_id: string;
+  nickname: string;
+  profileImage: string;
+}
+
+interface GroupMember extends RowDataPacket {
+  group_id: string;
+  user_id: string;
+  role: string;
+}
+
+interface Group extends RowDataPacket {
+  group_id: string;
+}
+
+export class SocketService {
+  private io: Server;
+  private pool: Pool;
+  private connectedUsers: Map<string, Set<string>> = new Map();
+
+  constructor(io: Server, pool: Pool) {
+    this.io = io;
+    this.pool = pool;
+  }
+
+  public initialize(): void {
+    this.io.on("connection", (socket: Socket) => {
+      console.log("Client connected:", socket.id);
+
+      this.handleJoinGroup(socket);
+      this.handleLeaveGroup(socket);
+      this.handleGetMembers(socket);
+      this.handleDeleteGroup(socket);
+      this.handleDisconnect(socket);
+    });
+  }
+
+  private async trackUserConnection(
+    groupId: string,
+    userId: string,
+    isConnecting: boolean
+  ) {
+    if (!this.connectedUsers.has(groupId)) {
+      this.connectedUsers.set(groupId, new Set());
+    }
+
+    const groupUsers = this.connectedUsers.get(groupId)!;
+
+    if (isConnecting) {
+      groupUsers.add(userId);
+    } else {
+      groupUsers.delete(userId);
+    }
+  }
+
+  private handleGetMembers(socket: Socket): void {
+    socket.on("getMembers", async (data: { groupId: string }) => {
+      const { groupId } = data;
+      const connection = await this.pool.getConnection();
+
+      try {
+        const [members] = await connection.query<(GroupMember & UserInfo)[]>(
+          `SELECT gm.group_id, gm.user_id, gm.role, u.nickname, u.profileImage 
+           FROM group_member_tb gm 
+           JOIN user_tb u ON gm.user_id = u.user_id 
+           WHERE gm.group_id = ?`,
+          [groupId]
+        );
+
+        socket.emit("membersList", {
+          groupId,
+          members: members.map((member) => ({
+            user_id: member.user_id,
+            nickname: member.nickname,
+            profileImage: member.profileImage,
+            role: member.role,
+          })),
+        });
+      } catch (error: any) {
+        console.error("Error in getMembers:", error);
+        socket.emit("error", {
+          message: error.message || "멤버 목록 조회 중 오류가 발생했습니다.",
+        });
+      } finally {
+        connection.release();
+      }
+    });
+  }
+
+  private handleJoinGroup(socket: Socket): void {
+    socket.on(
+      "joinGroup",
+      async (data: { groupId: string; userId: string }) => {
+        const { groupId, userId } = data;
+        const connection = await this.pool.getConnection();
+
+        try {
+          await connection.beginTransaction();
+
+          const [existingMember] = await connection.query<GroupMember[]>(
+            "SELECT * FROM group_member_tb WHERE group_id = ? AND user_id = ?",
+            [groupId, userId]
+          );
+
+          const [groupExists] = await connection.query<Group[]>(
+            "SELECT * FROM group_tb WHERE group_id = ?",
+            [groupId]
+          );
+
+          if (groupExists.length === 0) {
+            throw new Error("존재하지 않는 그룹입니다.");
+          }
+
+          socket.join(`group:${groupId}`);
+          await this.trackUserConnection(groupId, userId, true);
+
+          if (existingMember.length === 0) {
+            await connection.query(
+              'INSERT INTO group_member_tb (group_id, user_id, role) VALUES (?, ?, "COMPANION")',
+              [groupId, userId]
+            );
+
+            const [userInfo] = await connection.query<UserInfo[]>(
+              "SELECT user_id, nickname, profileImage FROM user_tb WHERE user_id = ?",
+              [userId]
+            );
+
+            this.io.to(`group:${groupId}`).emit("memberJoined", {
+              groupId,
+              newMember: userInfo[0],
+              message: "새로운 멤버가 참가했습니다.",
+            });
+          }
+
+          await connection.commit();
+        } catch (error: any) {
+          await connection.rollback();
+          console.error("Error in joinGroup:", error);
+          socket.emit("error", {
+            message: error.message || "멤버 추가 중 오류가 발생했습니다.",
+          });
+        } finally {
+          connection.release();
+        }
+      }
+    );
+  }
+
+  private handleLeaveGroup(socket: Socket): void {
+    socket.on(
+      "leaveGroup",
+      async (data: { groupId: string; userId: string }) => {
+        const { groupId, userId } = data;
+        const connection = await this.pool.getConnection();
+
+        try {
+          await connection.beginTransaction();
+
+          await this.trackUserConnection(groupId, userId, false);
+          socket.leave(`group:${groupId}`);
+
+          const [result] = await connection.query<any>(
+            'DELETE FROM group_member_tb WHERE group_id = ? AND user_id = ? AND role != "HOST"',
+            [groupId, userId]
+          );
+
+          if (result.affectedRows > 0) {
+            this.io.to(`group:${groupId}`).emit("memberLeft", {
+              groupId,
+              userId,
+              message: "멤버가 그룹을 나갔습니다.",
+            });
+          }
+
+          await connection.commit();
+        } catch (error: any) {
+          await connection.rollback();
+          socket.emit("error", {
+            message: error.message || "그룹 나가기 중 오류가 발생했습니다.",
+          });
+        } finally {
+          connection.release();
+        }
+      }
+    );
+  }
+  private handleDeleteGroup(socket: Socket): void {
+    socket.on(
+      "deleteGroup",
+      async (data: { groupId: string; userId: string }) => {
+        const { groupId, userId } = data;
+        const connection = await this.pool.getConnection();
+
+        try {
+          await connection.beginTransaction();
+
+          // 1. Check if user is HOST
+          const [userRole] = await connection.query<GroupMember[]>(
+            "SELECT role FROM group_member_tb WHERE group_id = ? AND user_id = ?",
+            [groupId, userId]
+          );
+
+          if (userRole[0]?.role !== "HOST") {
+            throw new Error("그룹 삭제 권한이 없습니다.");
+          }
+
+          // 2. Delete records from related tables in correct order
+          // First delete from group_invite_tb
+          await connection.query(
+            "DELETE FROM group_invite_tb WHERE group_id = ?",
+            [groupId]
+          );
+
+          // Delete from group_calendar_tb
+          await connection.query(
+            "DELETE FROM group_calendar_tb WHERE group_id = ?",
+            [groupId]
+          );
+
+          // Delete from group_member_tb
+          await connection.query(
+            "DELETE FROM group_member_tb WHERE group_id = ?",
+            [groupId]
+          );
+
+          // Finally delete from group_tb
+          await connection.query("DELETE FROM group_tb WHERE group_id = ?", [
+            groupId,
+          ]);
+
+          await connection.commit();
+
+          // Notify all members in the group
+          this.io.to(`group:${groupId}`).emit("groupDeleted", {
+            groupId,
+            message: "그룹이 삭제되었습니다.",
+          });
+
+          // Disconnect all sockets in the group room
+          const room = this.io.sockets.adapter.rooms.get(`group:${groupId}`);
+          if (room) {
+            room.forEach((socketId) => {
+              const clientSocket = this.io.sockets.sockets.get(socketId);
+              clientSocket?.leave(`group:${groupId}`);
+            });
+          }
+        } catch (error: any) {
+          await connection.rollback();
+          console.error("Error in deleteGroup:", error);
+          socket.emit("error", {
+            message: error.message || "그룹 삭제 중 오류가 발생했습니다.",
+          });
+        } finally {
+          connection.release();
+        }
+      }
+    );
+  }
+  private handleDisconnect(socket: Socket): void {
+    socket.on("disconnect", () => {
+      console.log("Client disconnected:", socket.id);
+      socket.rooms.forEach((room) => {
+        if (room.startsWith("group:")) {
+          const groupId = room.split(":")[1];
+          this.io.to(room).emit("userDisconnected", {
+            socketId: socket.id,
+            message: "사용자의 연결이 끊어졌습니다.",
+          });
+        }
+      });
+    });
+  }
+}

--- a/services/SocketService.ts
+++ b/services/SocketService.ts
@@ -218,6 +218,10 @@ export class SocketService {
               userId,
               message: "멤버가 그룹을 나갔습니다.",
             });
+            this.io.to(`group:${groupId}`).emit("calendarDateCleared", {
+              groupId,
+              userId,
+            });
           }
 
           await connection.commit();

--- a/services/calendarServices.ts
+++ b/services/calendarServices.ts
@@ -1,0 +1,214 @@
+import { Server, Socket } from "socket.io";
+import { Pool, RowDataPacket } from "mysql2/promise";
+
+interface CalendarData extends RowDataPacket {
+  calendar_id: number;
+  group_id: number;
+  user_id: number;
+  start_date: string;
+  end_date: string;
+  nickname: string;
+}
+
+interface DateRange {
+  start: string;
+  end: string;
+}
+
+export class CalendarSocketService {
+  private io: Server;
+  private pool: Pool;
+
+  constructor(io: Server, pool: Pool) {
+    this.io = io;
+    this.pool = pool;
+  }
+
+  public initialize(): void {
+    this.io.on("connection", (socket: Socket) => {
+      console.log("Calendar client connected:", socket.id);
+
+      // Handle joining group room
+      socket.on("joinGroup", (groupId: number) => {
+        socket.join(`group:${groupId}`);
+        console.log(`Client ${socket.id} joined group:${groupId}`);
+      });
+
+      this.handleSetCalendarDate(socket);
+      this.handleGetCalendarDates(socket);
+      this.handleClearCalendarDate(socket);
+      this.handleDisconnect(socket);
+    });
+  }
+
+  private handleSetCalendarDate(socket: Socket): void {
+    socket.on(
+      "setCalendarDate",
+      async (data: {
+        groupId: number;
+        userId: number;
+        dateRange: DateRange;
+      }) => {
+        const { groupId, userId, dateRange } = data;
+        const connection = await this.pool.getConnection();
+
+        try {
+          await connection.beginTransaction();
+
+          // Check if user is member of the group
+          const [memberCheck] = await connection.query<RowDataPacket[]>(
+            "SELECT * FROM group_member_tb WHERE group_id = ? AND user_id = ?",
+            [groupId, userId]
+          );
+
+          if (memberCheck.length === 0) {
+            throw new Error("그룹의 멤버가 아닙니다.");
+          }
+
+          // Delete existing calendar data for this user in this group
+          await connection.query(
+            "DELETE FROM group_calendar_tb WHERE group_id = ? AND user_id = ?",
+            [groupId, userId]
+          );
+
+          // Insert new calendar data
+          await connection.query(
+            `INSERT INTO group_calendar_tb 
+             (group_id, user_id, start_date, end_date) 
+             VALUES (?, ?, ?, ?)`,
+            [groupId, userId, dateRange.start, dateRange.end]
+          );
+
+          // Get updated calendar data including user nickname
+          const [updatedData] = await connection.query<CalendarData[]>(
+            `SELECT gc.*, u.nickname 
+             FROM group_calendar_tb gc
+             JOIN user_tb u ON gc.user_id = u.user_id
+             WHERE gc.group_id = ? AND gc.user_id = ?`,
+            [groupId, userId]
+          );
+
+          await connection.commit();
+
+          const calendarData = {
+            userId,
+            nickname: updatedData[0].nickname,
+            dateRange: {
+              start: dateRange.start,
+              end: dateRange.end,
+            },
+          };
+
+          // Broadcast to all clients in the group room, including sender
+          this.io.to(`group:${groupId}`).emit("calendarUpdated", {
+            groupId,
+            calendarData,
+          });
+
+          // Send specific success response to sender
+          socket.emit("calendarUpdateSuccess", {
+            groupId,
+            calendarData,
+            message: "일정이 성공적으로 업데이트되었습니다.",
+          });
+        } catch (error: any) {
+          await connection.rollback();
+          console.error("Error in setCalendarDate:", error);
+          socket.emit("error", {
+            message: error.message || "일정 설정 중 오류가 발생했습니다.",
+          });
+        } finally {
+          connection.release();
+        }
+      }
+    );
+  }
+
+  private handleGetCalendarDates(socket: Socket): void {
+    socket.on("getCalendarDates", async (data: { groupId: number }) => {
+      const { groupId } = data;
+      const connection = await this.pool.getConnection();
+
+      try {
+        const [calendarData] = await connection.query<CalendarData[]>(
+          `SELECT gc.*, u.nickname 
+           FROM group_calendar_tb gc
+           JOIN user_tb u ON gc.user_id = u.user_id
+           WHERE gc.group_id = ?`,
+          [groupId]
+        );
+
+        const formattedData = calendarData.map((data) => ({
+          userId: data.user_id,
+          nickname: data.nickname,
+          dateRange: {
+            start: data.start_date,
+            end: data.end_date,
+          },
+        }));
+
+        socket.emit("calendarDatesList", {
+          groupId,
+          calendarData: formattedData,
+        });
+      } catch (error: any) {
+        console.error("Error in getCalendarDates:", error);
+        socket.emit("error", {
+          message: error.message || "일정 조회 중 오류가 발생했습니다.",
+        });
+      } finally {
+        connection.release();
+      }
+    });
+  }
+
+  private handleClearCalendarDate(socket: Socket): void {
+    socket.on(
+      "clearCalendarDate",
+      async (data: { groupId: number; userId: number }) => {
+        const { groupId, userId } = data;
+        const connection = await this.pool.getConnection();
+
+        try {
+          await connection.beginTransaction();
+
+          const [result] = await connection.query<any>(
+            "DELETE FROM group_calendar_tb WHERE group_id = ? AND user_id = ?",
+            [groupId, userId]
+          );
+
+          await connection.commit();
+
+          if (result.affectedRows > 0) {
+            // Broadcast to all clients in the group room
+            this.io.to(`group:${groupId}`).emit("calendarDateCleared", {
+              groupId,
+              userId,
+            });
+
+            // Send specific success response to sender
+            socket.emit("calendarClearSuccess", {
+              groupId,
+              userId,
+              message: "일정이 성공적으로 초기화되었습니다.",
+            });
+          }
+        } catch (error: any) {
+          await connection.rollback();
+          console.error("Error in clearCalendarDate:", error);
+          socket.emit("error", {
+            message: error.message || "일정 초기화 중 오류가 발생했습니다.",
+          });
+        } finally {
+          connection.release();
+        }
+      }
+    );
+  }
+
+  private handleDisconnect(socket: Socket): void {
+    socket.on("disconnect", () => {
+      console.log("Calendar client disconnected:", socket.id);
+    });
+  }
+}

--- a/services/group.ts
+++ b/services/group.ts
@@ -1,0 +1,81 @@
+import { Pool, RowDataPacket, ResultSetHeader } from "mysql2/promise";
+import { CreateGroupDto, GroupDetails, GroupMember } from "../types/group";
+
+class GroupService {
+  private db: Pool;
+
+  constructor(db: Pool) {
+    this.db = db;
+  }
+
+  //  실패 케이스 (트랜잭션이 없다면):
+  // 1. group_tb INSERT 성공
+  // 2. group_member_tb INSERT 실패
+  // -> 호스트 없는 그룹이 남게 됨
+
+  //  트랜잭션 사용 시:
+  // 1. group_tb INSERT 성공
+  // 2. group_member_tb INSERT 실패
+  // 3. 전체 롤백 -> 데이터 일관성 유지
+  public async createGroup(
+    groupData: CreateGroupDto,
+    userId: Number
+  ): Promise<GroupDetails> {
+    const connection = await this.db.getConnection();
+    try {
+      await connection.beginTransaction();
+
+      // 그룹 생성
+      const [groupResult] = await connection.query<ResultSetHeader>(
+        "INSERT INTO group_tb (name, host_id) VALUES (?, ?)",
+        [groupData.name, userId]
+      );
+      const groupId = groupResult.insertId;
+
+      // 생성자를 HOST로 멤버 추가
+      await connection.query(
+        "INSERT INTO group_member_tb (group_id, user_id, role) VALUES (?, ?, 'HOST')",
+        [groupId, userId]
+      );
+      // 생성된 그룹 정보 조회
+      const [groups] = await connection.query<RowDataPacket[]>(
+        "SELECT group_id, host_id FROM group_tb WHERE group_id = ?",
+        [groupId]
+      );
+
+      await connection.commit();
+      return groups[0] as GroupDetails;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+  public async getGroupDetails(groupId: number): Promise<GroupDetails> {
+    const [groups] = await this.db.query<RowDataPacket[]>(
+      "SELECT * FROM group_tb WHERE group_id = ?",
+      [groupId]
+    );
+
+    if (groups.length === 0) {
+      throw new Error("존재하지 않는 그룹입니다.");
+    }
+
+    return groups[0] as GroupDetails;
+  }
+
+  public async getGroupMembers(groupId: number): Promise<GroupMember[]> {
+    const [members] = await this.db.query<RowDataPacket[]>(
+      `SELECT u.user_id, u.nickname, u.profileImage, gm.role
+       FROM group_member_tb gm
+       JOIN user_tb u ON gm.user_id = u.user_id
+       WHERE gm.group_id = ?
+       ORDER BY gm.role = 'HOST' DESC, gm.joined_date ASC`,
+      [groupId]
+    );
+
+    return members as GroupMember[];
+  }
+}
+export default GroupService;

--- a/services/kakao.ts
+++ b/services/kakao.ts
@@ -3,11 +3,10 @@ import axios from "axios";
 import { generateToken, generateRefreshToken } from "../authorization/jwt";
 class KakaoService {
   private db: Pool;
-  private readonly KAKAO_CLIENT_ID: string = "38789b5f2f2e16d6229dbc25dc0c776b";
+  private readonly KAKAO_CLIENT_ID: string = process.env.KAKAO_CLIENT_ID!;
   private readonly KAKAO_CLIENT_SECRET: string =
-    "Z9bv6VkeepRe2CmkjuPdgLY0HA1x7lGf";
-  private readonly REDIRECT_URI: string =
-    "http://healthkungya.s3-website.ap-northeast-2.amazonaws.com/oauth/kakao/callback";
+    process.env.KAKAO_CLIENT_SECRET!;
+  private readonly REDIRECT_URI: string = process.env.REDIRECT_URI!;
 
   constructor(db: Pool) {
     this.db = db;

--- a/services/kakao.ts
+++ b/services/kakao.ts
@@ -28,10 +28,10 @@ class KakaoService {
       const user = await this.findOrCreateUser(kakaoUser);
 
       // 4. JWT 토큰 생성
-      const tokens = this.generateUserTokens(kakaoUser.userId);
+      const tokens = this.generateUserTokens(user.user_id);
       return {
         user: {
-          id: user.id,
+          id: user.user_id,
           nickname: user.nickname,
           profileImage: user.profileImage,
         },
@@ -127,18 +127,16 @@ class KakaoService {
     }
   }
 
-  private generateUserTokens(kakaoId: string) {
+  private generateUserTokens(userId: string) {
     return {
-      accessToken: generateToken({ id: kakaoId }),
-      refreshToken: generateRefreshToken({
-        id: kakaoId,
-      }),
+      accessToken: generateToken({ user_id: userId }),
+      refreshToken: generateRefreshToken({ user_id: userId }),
     };
   }
   public async getUserProfile(userId: number) {
     try {
       const [users] = await this.db.query<RowDataPacket[]>(
-        "SELECT id, nickname,  profileImage FROM user_tb WHERE id = ?",
+        "SELECT user_id, nickname,  profileImage FROM user_tb WHERE user_id = ?",
         [userId]
       );
 

--- a/types/group.ts
+++ b/types/group.ts
@@ -1,0 +1,17 @@
+export interface CreateGroupDto {
+  name: string;
+}
+
+export interface GroupDetails {
+  group_id: number;
+  name: string;
+  host_id: number;
+  created_date: Date;
+}
+
+export interface GroupMember {
+  user_id: number;
+  nickname: string;
+  profileImage: string;
+  role: "HOST" | "COMPANION";
+}


### PR DESCRIPTION
## PR 유형

어떤 종류의 변경 사항인가요? (해당 사항에 모두 체크)

- [ ] 버그 수정 (기존 문제를 수정)
- [x] 기능 추가 (새로운 기능)
- [ ] 코드 스타일 수정 (포맷팅, 세미콜론 수정 등, 논리적 변경 없음)
- [ ] 리팩토링 (기능 수정 없이 코드 리팩토링)
- [ ] 문서 수정 (문서 추가 또는 수정)
- [ ] 테스트 추가 (기존 코드에 대한 테스트 추가)
- [ ] 빌드 또는 CI 관련 변경 사항

## PR 설명

**초대 링크 생성**
   - 사용자가 그룹 초대 링크를 생성할 수 있는 기능 추가.
   - 고유한 URL 생성 및 유효기간 설정 가능.
2. **그룹 자동 참여**
   - 초대 링크를 통해 접속한 사용자는 인증 후 자동으로 그룹에 추가.
   - 서버에 유저 정보와 그룹 참여 내역이 실시간 업데이트됨.
3. **실시간 달력 공유 및 일정 확정**
   - 그룹 내 모든 유저가 동일한 달력을 실시간 공유.
   - WebSocket을 통해 일정 생성, 수정, 확정이 모든 멤버 화면에 즉시 반영.
   - 일정 확정 시 알림 기능 추가.
4. **그룹 탈퇴 기능**
   - 동행인 탈퇴 시 해당 유저 정보 및 일정만 삭제.
   - 호스트 탈퇴 시 그룹 전체 삭제.
5. **실시간 데이터 동기화**
   - 탈퇴 요청 발생 시 WebSocket을 통해 그룹 내 모든 멤버 화면에 즉시 반영.

### 현재 동작

현재는 그룹 초대와 실시간 일정 관리 기능이 제공되지 않으며, 그룹 탈퇴 시 데이터 동기화 및 관리가 수동으로 이루어짐.

### 새로운 동작

변경 후에는:
- 초대 링크를 통해 손쉽게 그룹원을 추가할 수 있음.
- 실시간 달력 공유 및 일정 확정 기능으로 협업 강화.
- 탈퇴 요청 시 실시간 데이터 동기화로 그룹 상태가 즉시 반영됨.

### 변경 이유

- **사용자 편의성 개선**: 간단한 초대 링크로 그룹 관리 및 참여를 더 효율적으로 처리하기 위해.
- **실시간 협업 강화**: 그룹 멤버 간의 원활한 소통과 일정을 즉각적으로 반영하기 위해.
- **데이터 정리**: 탈퇴 시 불필요한 데이터를 정리하여 앱의 데이터 무결성을 유지하기 위해.

## 이슈

## 기능 설명

초대 링크 생성

사용자가 그룹 초대 링크를 생성할 수 있습니다.
초대 링크는 고유한 URL로 생성되며, 유효기간을 설정할 수 있습니다.
그룹 자동 참여

초대 링크를 통해 접속한 유저는 인증 후 그룹에 자동으로 추가됩니다.
유저 정보와 그룹 참여 내역이 서버에 실시간으로 업데이트됩니다.
실시간 달력 공유 및 일정 확정

그룹 내 모든 유저가 동일한 달력을 실시간으로 공유합니다.
소켓 통신을 통해 일정 생성, 수정, 확정 사항이 즉시 모든 유저 화면에 반영됩니다.
일정 확정 시 알림 기능으로 참여 유저들에게 업데이트 내용을 즉시 전송합니다.

그룹 탈퇴 기능

동행인 탈퇴:
그룹 내 동행인이 나가면, 해당 유저의 정보와 일정 참여 내역만 삭제됩니다.
다른 멤버나 그룹의 데이터는 유지됩니다.
호스트 탈퇴:
그룹의 호스트가 나가면, 해당 그룹 및 관련 일정, 데이터가 모두 삭제됩니다.
호스트는 탈퇴 전, 확인 창을 통해 삭제 의사를 재확인합니다.
실시간 데이터 동기화

탈퇴 요청이 발생하면, WebSocket을 통해 그룹 내 모든 멤버의 화면에 즉시 반영됩니다.
동행인이 탈퇴 시 남은 멤버 목록 및 일정에서 해당 동행인의 정보가 실시간으로 업데이트됩니다.
호스트 탈퇴 시, 그룹이 종료되었음을 모든 멤버에게 알림으로 전달합니다.

## 기대 효과

손쉬운 그룹 초대 및 관리

링크 하나로 간편하게 그룹원을 초대하고 관리할 수 있어, 사용자의 편의성이 대폭 향상됩니다.
실시간 협업 강화

실시간 달력 공유와 일정 확정 기능을 통해 그룹 멤버 간의 협업을 원활히 진행할 수 있습니다.
효율적인 일정 관리

일정 변경 사항이 즉시 반영되어, 불필요한 커뮤니케이션 없이 효율적인 일정 관리가 가능합니다.
유연한 참여 방식 제공

초대 링크를 통한 접근은 비회원 또는 새로운 사용자에게도 쉽게 그룹 참여를 유도할 수 있습니다.

유연한 그룹 관리

동행인이 나가더라도 그룹 전체에는 영향을 미치지 않아, 원활한 일정 진행이 가능합니다.
호스트 탈퇴 시, 그룹이 자동 삭제되어 불필요한 데이터가 남지 않습니다.
데이터 정리

불필요한 데이터(탈퇴한 유저 정보, 일정 참여 내역 등)가 즉시 삭제되어, 그룹 데이터가 깔끔하게 유지됩니다.
실시간 협업 유지

탈퇴 상황이 실시간으로 반영되므로, 다른 멤버들에게 혼동을 주지 않습니다.

## 추가 정보

기타 참고할 사항이 있다면 작성해주세요.


#3 

만약 PR이 병합될 때 함께 닫고자 하는 이슈는 아래와 같이 작성해주세요

예: resolves #<이슈 번호>
