### PR TITLE
Feat3/create trip

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -4,6 +4,7 @@ import { createServer } from "http";
 import { Server } from "socket.io";
 import kakaoRouter from "./router/kakao";
 import groupRouter from "./router/group";
+import tripRouter from "./router/trip";
 import { Pool, createPool } from "mysql2/promise";
 import { SocketService } from "./services/SocketService";
 import dbConfig from "./config/db.config";
@@ -48,6 +49,7 @@ app.set("port", process.env.PORT || 8000);
 
 app.use("/auth", kakaoRouter);
 app.use("/group", groupRouter);
+app.use("/trip", tripRouter);
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));
 
 // Socket.IO 서비스 초기화

--- a/controller/trip.ts
+++ b/controller/trip.ts
@@ -20,10 +20,16 @@ class TripController {
       if (!req.user?.user_id) {
         return res.status(401).json({ error: "인증이 필요합니다." });
       }
-      const { groupId, date, days } = req.body;
+      const { groupId, groupName, groupThumbnail, date, days } = req.body;
       console.log(date);
 
-      const trip = await this.tripService.createTrip(groupId, date, days);
+      const trip = await this.tripService.createTrip(
+        groupId,
+        groupName,
+        groupThumbnail,
+        date,
+        days
+      );
 
       res.status(201).json({ message: "성공적으로 저장되었습니다", trip });
     } catch (error) {
@@ -45,6 +51,19 @@ class TripController {
     } catch (error) {
       console.error("여행 조회 에러:", error);
       res.status(500).json({ error: "여행 조회에 실패 했습니다." });
+    }
+  };
+
+  public getMyGroupTrips = async (req: AuthRequest, res: Response) => {
+    try {
+      if (!req.user?.user_id) {
+        return res.status(401).json({ error: "인증이 필요합니다." });
+      }
+      const myGroupTrip = await this.tripService.getUserTrips(req.user.user_id);
+      res.json(myGroupTrip);
+    } catch (error) {
+      console.error("나의 여행 그룹 조회 에러", error);
+      res.status(500).json({ error: "나의 여행 그룹 조회에 실패 했습니다." });
     }
   };
 }

--- a/controller/trip.ts
+++ b/controller/trip.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from "express";
+import TripService from "../services/trip";
+import connection from "../db";
+interface DecodedToken {
+  user_id: number;
+  iat: number;
+  exp: number;
+}
+interface AuthRequest extends Request {
+  user?: DecodedToken;
+}
+class TripController {
+  private tripService: TripService;
+  constructor() {
+    this.tripService = new TripService(connection);
+  }
+
+  public createTrip = async (req: AuthRequest, res: Response) => {
+    try {
+      if (!req.user?.user_id) {
+        return res.status(401).json({ error: "인증이 필요합니다." });
+      }
+      const { groupId, startDate, endDate, destination, locations } = req.body;
+
+      const trip = await this.tripService.createTrip(
+        groupId,
+        startDate,
+        endDate,
+        destination,
+        locations
+      );
+
+      res.status(201).json(trip);
+    } catch (error) {
+      console.error("여행 생성 에러:", error);
+      res.status(500).json({ error: "여행 생성에 실패했습니다." });
+    }
+  };
+
+  public getTripDetails = async (req: AuthRequest, res: Response) => {
+    try {
+      const { tripId } = req.params;
+      if (!req.user?.user_id) {
+        return res.status(401).json({ error: "인증이 필요합니다." });
+      }
+      const tripDetails = await this.tripService.getTripDetails(
+        parseInt(tripId)
+      );
+      res.json(tripDetails);
+    } catch (error) {
+      console.error("여행 조회 에러:", error);
+      res.status(500).json({ error: "여행 조회에 실패 했습니다." });
+    }
+  };
+}
+export default TripController;

--- a/controller/trip.ts
+++ b/controller/trip.ts
@@ -20,17 +20,12 @@ class TripController {
       if (!req.user?.user_id) {
         return res.status(401).json({ error: "인증이 필요합니다." });
       }
-      const { groupId, startDate, endDate, destination, locations } = req.body;
+      const { groupId, date, days } = req.body;
+      console.log(date);
 
-      const trip = await this.tripService.createTrip(
-        groupId,
-        startDate,
-        endDate,
-        destination,
-        locations
-      );
+      const trip = await this.tripService.createTrip(groupId, date, days);
 
-      res.status(201).json(trip);
+      res.status(201).json({ message: "성공적으로 저장되었습니다", trip });
     } catch (error) {
       console.error("여행 생성 에러:", error);
       res.status(500).json({ error: "여행 생성에 실패했습니다." });

--- a/router/trip.ts
+++ b/router/trip.ts
@@ -7,7 +7,7 @@ const tripController = new TripController();
 
 // 여행 생성
 router.post("/", verifyTokenMiddleware, tripController.createTrip);
-
+router.get("/mytrip", verifyTokenMiddleware, tripController.getMyGroupTrips);
 // 여행 상세 조회
 router.get("/:tripId", verifyTokenMiddleware, tripController.getTripDetails);
 

--- a/router/trip.ts
+++ b/router/trip.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import TripController from "../controller/trip";
+import { verifyTokenMiddleware } from "../authorization/jwt";
+
+const router: Router = Router();
+const tripController = new TripController();
+
+// 여행 생성
+router.post("/", verifyTokenMiddleware, tripController.createTrip);
+
+// 여행 상세 조회
+router.get("/:tripId", verifyTokenMiddleware, tripController.getTripDetails);
+
+export default router;

--- a/services/trip.ts
+++ b/services/trip.ts
@@ -1,0 +1,135 @@
+import { Pool, RowDataPacket, ResultSetHeader } from "mysql2/promise";
+import {
+  TripDetails,
+  TripLocationDetails,
+  TripWithMembers,
+} from "../types/trip";
+
+class TripService {
+  private db: Pool;
+
+  constructor(db: Pool) {
+    this.db = db;
+  }
+
+  public async createTrip(
+    groupId: number,
+    startDate: string,
+    endDate: string,
+    destination: string,
+    locations: Array<{
+      day: number;
+      name: string;
+      address: string;
+      visitTime: string;
+      category: string;
+      hashtag: string;
+      thumbnail: string;
+    }>
+  ): Promise<TripDetails> {
+    const connection = await this.db.getConnection();
+    try {
+      await connection.beginTransaction();
+
+      // Trip 생성
+      const [tripResult] = await connection.query<ResultSetHeader>(
+        "INSERT INTO trip_tb (group_id, start_date, end_date, destination) VALUES (?, ?, ?, ?)",
+        [groupId, startDate, endDate, destination]
+      );
+      const tripId = tripResult.insertId;
+
+      // Locations 추가
+      for (const location of locations) {
+        await connection.query(
+          "INSERT INTO trip_location_tb (trip_id, day, name, address, visit_time, category, hashtag, thumbnail) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+          [
+            tripId,
+            location.day,
+            location.name,
+            location.address,
+            location.visitTime,
+            location.category,
+            location.hashtag,
+            location.thumbnail,
+          ]
+        );
+      }
+
+      await connection.commit();
+      return {
+        trip_id: tripId,
+        group_id: groupId,
+        start_date: startDate,
+        end_date: endDate,
+        destination,
+      } as TripDetails;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  public async getTripDetails(tripId: number): Promise<TripWithMembers> {
+    const connection = await this.db.getConnection();
+    try {
+      // Trip 정보 조회
+      const [trips] = await connection.query<RowDataPacket[]>(
+        `SELECT t.*, g.name as group_name 
+         FROM trip_tb t
+         JOIN group_tb g ON t.group_id = g.group_id
+         WHERE t.trip_id = ?`,
+        [tripId]
+      );
+
+      if (trips.length === 0) {
+        throw new Error("존재하지 않는 여행입니다.");
+      }
+
+      // Trip Locations 조회
+      const [locations] = await connection.query<RowDataPacket[]>(
+        `SELECT * FROM trip_location_tb 
+         WHERE trip_id = ? 
+         ORDER BY day, visit_time`,
+        [tripId]
+      );
+
+      // Trip에 참여한 멤버 조회 (nickname 포함)
+      const [members] = await connection.query<RowDataPacket[]>(
+        `SELECT u.user_id, u.nickname, u.profileImage, gm.role
+         FROM group_member_tb gm
+         JOIN user_tb u ON gm.user_id = u.user_id
+         WHERE gm.group_id = ?
+         ORDER BY gm.role = 'HOST' DESC, gm.joined_date ASC`,
+        [trips[0].group_id]
+      );
+
+      return {
+        ...trips[0],
+        locations: locations as TripLocationDetails[],
+        members: members.map((member) => ({
+          user_id: member.user_id,
+          nickname: member.nickname,
+          profileImage: member.profileImage,
+          role: member.role,
+        })),
+      } as TripWithMembers;
+    } catch (error) {
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  public async getGroupTrips(groupId: number): Promise<TripDetails[]> {
+    const [trips] = await this.db.query<RowDataPacket[]>(
+      "SELECT * FROM trip_tb WHERE group_id = ? ORDER BY start_date DESC",
+      [groupId]
+    );
+
+    return trips as TripDetails[];
+  }
+}
+
+export default TripService;

--- a/types/trip.ts
+++ b/types/trip.ts
@@ -1,9 +1,7 @@
 export interface TripDetails {
   trip_id: number;
   group_id: number;
-  start_date: string;
-  end_date: string;
-  destination: string;
+  date: string;
   created_date?: string;
   updated_date?: string;
 }

--- a/types/trip.ts
+++ b/types/trip.ts
@@ -1,6 +1,8 @@
 export interface TripDetails {
   trip_id: number;
   group_id: number;
+  groupName: string;
+  groupThumbnail: string;
   date: string;
   created_date?: string;
   updated_date?: string;
@@ -28,4 +30,9 @@ export interface TripWithMembers extends TripDetails {
     profileImage?: string;
     role: string;
   }>;
+}
+export interface TripInfo {
+  trip_id: number;
+  date: string; // "2024.11.05~2024.11.08" 형식
+  group_name: string;
 }

--- a/types/trip.ts
+++ b/types/trip.ts
@@ -1,0 +1,33 @@
+export interface TripDetails {
+  trip_id: number;
+  group_id: number;
+  start_date: string;
+  end_date: string;
+  destination: string;
+  created_date?: string;
+  updated_date?: string;
+}
+
+export interface TripLocationDetails {
+  location_id: number;
+  trip_id: number;
+  day: number;
+  name: string;
+  address: string;
+  visit_time: string;
+  category: string;
+  hashtag: string;
+  thumbnail: string;
+  created_date?: string;
+}
+
+export interface TripWithMembers extends TripDetails {
+  group_name: string;
+  locations: TripLocationDetails[];
+  members: Array<{
+    user_id: number;
+    nickname: string;
+    profileImage?: string;
+    role: string;
+  }>;
+}


### PR DESCRIPTION
## PR 유형

어떤 종류의 변경 사항인가요? (해당 사항에 모두 체크)

- [ ] 버그 수정 (기존 문제를 수정)
- [x] 기능 추가 (새로운 기능)
- [ ] 코드 스타일 수정 (포맷팅, 세미콜론 수정 등, 논리적 변경 없음)
- [ ] 리팩토링 (기능 수정 없이 코드 리팩토링)
- [ ] 문서 수정 (문서 추가 또는 수정)
- [ ] 테스트 추가 (기존 코드에 대한 테스트 추가)
- [ ] 빌드 또는 CI 관련 변경 사항

---

## PR 설명

변경 사항에 대해 자세히 설명해주세요. 무엇이 변경되었는지, 왜 이러한 변경이 필요한지 설명합니다.

### 현재 동작

현재는 그룹 생성 및 여행 일정 관리를 위한 기본적인 기능이 제공되지 않습니다.  
사용자가 속한 트립 그룹을 한눈에 볼 수 없고, 각 그룹의 일정에 접근하기 위한 기능이 없습니다.

### 새로운 동작

1. **그룹 생성 및 방 생성**
   - 새로운 그룹을 생성하고, 여행 방을 추가할 수 있습니다.
   - 방 내에서 세부 일정을 관리하는 기능을 제공합니다.

2. **여행 일정 조회**
   - 그룹 내 여행 일정 정보를 조회할 수 있는 기능을 추가했습니다.
   - 그룹원들이 공유한 일정과 세부 정보를 한눈에 확인할 수 있습니다.

3. **마이트립그룹 리스트 조회 및 이동**
   - 사용자가 속한 모든 트립 그룹을 리스트로 확인 가능.
   - 특정 트립 그룹을 선택하면 해당 그룹의 페이지로 이동하여 관리와 일정 조회가 가능합니다.

---

### 변경 이유

- 사용자에게 직관적이고 편리한 그룹 관리 경험을 제공하기 위해.
- 그룹 내 일정 공유와 협업을 원활히 진행할 수 있도록 지원.
- 사용자가 속한 여러 그룹에 빠르게 접근할 수 있는 방식을 도입하기 위해.

---
## 이슈

## 기능 설명

1. **그룹 생성 및 방 생성 기능**
   - 사용자가 새로운 그룹을 생성할 수 있는 기능을 제공합니다.
   - 그룹 생성 후 여행 방을 생성하여 그룹 내에서 세부 일정을 관리할 수 있습니다.

2. **여행 일정 조회**
   - 생성된 여행 방에서 여행 일정을 조회할 수 있는 기능을 추가했습니다.
   - 그룹원과 함께 공유된 일정이 한눈에 확인 가능하며, 세부적인 일정 내용도 확인할 수 있습니다.

3. **마이트립그룹 리스트 조회**
   - 사용자가 속한 모든 트립 그룹을 리스트 형식으로 확인할 수 있습니다.
   - 리스트에서 특정 트립 그룹을 선택하면 해당 그룹 페이지로 이동하여 관리 및 일정 확인이 가능합니다.

---

## 기대 효과

1. **사용자 편의성 향상**
   - 그룹과 방 생성 과정을 간소화하여 사용자가 더 빠르게 여행 계획을 세울 수 있습니다.
   - 자신이 속한 트립 그룹을 한곳에서 확인 가능하므로 편리한 이동 제공.

2. **효율적인 일정 관리**
   - 그룹 내에서 여행 일정을 조회 및 공유할 수 있어 협업과 계획 관리가 용이해집니다.
   - 세부 일정 확인 기능으로 그룹원 간의 소통이 원활해집니다.

3. **데이터 정리 및 접근성 개선**
   - 사용자가 속한 트립 그룹과 여행 일정을 정리하여 데이터 접근성과 유지 관리 효율성 증대.

4. **그룹 중심 커뮤니케이션 강화**
   - 그룹 중심의 여행 관리와 일정 공유로 협업이 강화되고, 모든 멤버가 계획에 쉽게 접근 가능.

---

## 추가 정보

기타 참고할 사항이 있다면 작성해주세요.


#5 

만약 PR이 병합될 때 함께 닫고자 하는 이슈는 아래와 같이 작성해주세요

예: resolves #<이슈 번호>
