### PR TITLE
feat: 전에 일정 생성방 목록 조회 및 페이먼츠 개인 품목 수정

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -7,6 +7,7 @@ import groupRouter from "./router/group";
 import tripRouter from "./router/trip";
 import paymentRouter from "./router/payment";
 import imageRouter from "./router/image";
+import previousRouter from "./router/previous";
 import { Pool, createPool } from "mysql2/promise";
 import { SocketService } from "./services/SocketService";
 import dbConfig from "./config/db.config";
@@ -58,6 +59,7 @@ app.use("/group", groupRouter);
 app.use("/trip", tripRouter);
 app.use("/payment", paymentRouter);
 app.use("/image", imageRouter);
+app.use("/previous", previousRouter);
 // app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));
 
 // Socket.IO 서비스 초기화

--- a/controller/group.ts
+++ b/controller/group.ts
@@ -186,5 +186,23 @@ class GroupController {
       }
     });
   };
+
+  public getPreviousGroup = async (req: AuthRequest, res: Response) => {
+    try {
+      if (!req.user?.user_id) {
+        return res.status(401).json({ error: "인증이 필요합니다." });
+      }
+
+      const previousGroup = await this.groupService.getPreviousGroup(
+        req.user.user_id
+      );
+      res.status(201).json(previousGroup);
+    } catch (error) {
+      console.error("이전 일정 생성 그룹 조회 에러:", error);
+      res
+        .status(500)
+        .json({ error: "이전 일정 생성 그룹 조회에 실패했습니다." });
+    }
+  };
 }
 export default GroupController;

--- a/controller/payment.ts
+++ b/controller/payment.ts
@@ -70,7 +70,8 @@ class PaymentController {
       }
 
       const payments = await this.paymentService.getPaymentsByTripId(
-        parseInt(tripId)
+        parseInt(tripId),
+        req.user.user_id
       );
 
       res.status(201).json(payments);

--- a/router/previous.ts
+++ b/router/previous.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import GroupController from "../controller/group";
+import { verifyTokenMiddleware } from "../authorization/jwt";
+
+const router: Router = Router();
+const groupController = new GroupController();
+
+router.get("/", verifyTokenMiddleware, groupController.getPreviousGroup);
+
+export default router;

--- a/services/group.ts
+++ b/services/group.ts
@@ -148,5 +148,17 @@ class GroupService {
 
     return members as GroupMember[];
   }
+  public async getPreviousGroup(userId: number): Promise<number[]> {
+    const [groupIds] = await this.db.query<RowDataPacket[]>(
+      `SELECT g.group_id 
+       FROM group_tb g
+       INNER JOIN group_member_tb gm ON g.group_id = gm.group_id
+       WHERE gm.user_id = ? AND g.schedule = false
+       ORDER BY g.created_date DESC`,
+      [userId]
+    );
+
+    return groupIds.map((row) => row.group_id);
+  }
 }
 export default GroupService;


### PR DESCRIPTION
## PR 유형

- [ ] 버그 수정 (기존 문제를 수정)
- [x] 기능 추가 (새로운 기능)
- [ ] 코드 스타일 수정 (포맷팅, 세미콜론 수정 등, 논리적 변경 없음)
- [ ] 리팩토링 (기능 수정 없이 코드 리팩토링)
- [ ] 문서 수정 (문서 추가 또는 수정)
- [ ] 테스트 추가 (기존 코드에 대한 테스트 추가)
- [ ] 빌드 또는 CI 관련 변경 사항

## PR 설명

### 현재 동작
현재 애플리케이션은 어플 종료 후 이전에 생성한 일정을 확인할 수 없으며, 개인 가계부 결제 내역 조회 시 일부 오류가 발생하고 있습니다.

### 새로운 동작
- 사용자가 어플 종료 후 재접속 시, 서버에서 해당 사용자의 방 정보를 조회하고 이전에 생성한 일정 목록을 모달로 표시하여 확인할 수 있습니다.
- 결제 내역 조회 시 개인 가계부의 관련 버그가 수정되어 정상적으로 작동하도록 개선되었습니다.

### 변경 이유
- **이전 일정 확인 기능 추가 이유**: 사용자가 어플을 종료하고 다시 접속해도 이전 일정 데이터를 손쉽게 확인할 수 있도록 하여 사용자 편의성과 어플의 사용성을 개선하기 위해 추가했습니다.
- **결제 내역 버그 수정 이유**: 개인 가계부 기능에서 발생한 결제 내역 조회 오류를 수정하여 정확한 정보 제공과 사용자 신뢰도를 높이기 위해 필요했습니다.

## 이슈

## 기능 설명
  - 서버에서 사용자가 속한 방 정보를 조회하여 필요한 데이터를 제공.  
  - 개인 가계부 관련 버그를 수정하여 결제 내역 조회가 정상적으로 작동하도록 개선.  

## 기대 효과

- **이전 일정 확인 및 지속성 제공**  
  - 사용자가 어플 종료 후에도 이전에 생성한 일정을 쉽게 확인하고 이어서 작업 가능.  
  - 사용자 편의성을 대폭 향상시켜 어플의 지속적인 사용성을 보장.  

- **결제 내역 신뢰성 향상**  
  - 가계부 관련 버그를 해결하여 사용자에게 정확하고 신뢰할 수 있는 결제 내역 제공.  
  - 데이터 일관성과 안정성 확보로 사용자 경험 개선. 

## 추가 정보

기타 참고할 사항이 있다면 작성해주세요.


#16 


